### PR TITLE
Etcd storage documentation

### DIFF
--- a/docs/current/README.md
+++ b/docs/current/README.md
@@ -144,11 +144,11 @@ Log:
 - `ServerClient`: Configuration for vaquero-agent's ServerAPI client.
 - `ServerAPI`: The vaquero-server api, used by vaquero agents.
 - `AssetServer`: The asset server for Vaquero agent used by each booting machine to get unattended scripts and kernels.
-- `SavePath`: The Vaquero server location to save local configurations (data models) on disk.
 - `Gitter`: Configuration for listening to git webhooks.
 - `GitHook`: An array for all githooks to listen to.
 - `SoT:` An array for specific sources of truth. Git updater receives webhooks from github. Local: will use a local directory to update.
 - `Etcd`: The necessary information to connect a vaquero server cluster or High Availability (HA) cluster to a running [CoreOS Etcd](https://coreos.com/etcd/) cluster. If Etcd information is provided, Vaquero will use the provided cluster endpoints (vs. a local filestorage) to store and continuously update data model information, as well as internal, vaquero-specific information (eg. machine state). See the [Getting Started page](https://ciscocloud.github.io/vaquero-docs/docs/current/getting-started.html), under "Etcd and Vaquero," for more information, including a short demo using a virtual machine running Etcd.
+- `SavePath`: If no Etcd details provided, the local dir where Vaquero servers and agents will save local configurations, as well as internal information (eg. machine state) needed for Vaquero to run.
 - `DHCPMode`:Using "server" runs Vaquero as a DHCP server.  Vaquero does not manage free address pools or leases; it simply assigns based of the static configuration defined in the data model. **Note that DHCPMode defaults to server.** Using "proxy" enables ProxyDHCP. ProxyDHCP works with an existing DHCP Server to provide PXEBoot functionality, while leaving the managing and assigning of IP addresses to the other DHCP Server. Only enable this if you already have a DHCP server with entries for all the hosts in your Data Model.
 
 

--- a/docs/current/README.md
+++ b/docs/current/README.md
@@ -144,11 +144,11 @@ Log:
 - `ServerClient`: Configuration for vaquero-agent's ServerAPI client.
 - `ServerAPI`: The vaquero-server api, used by vaquero agents.
 - `AssetServer`: The asset server for Vaquero agent used by each booting machine to get unattended scripts and kernels.
-- `SavePath`: The Vaquero server location to save local configurations on disk.
+- `SavePath`: The Vaquero server location to save local configurations (data models) on disk.
 - `Gitter`: Configuration for listening to git webhooks.
 - `GitHook`: An array for all githooks to listen to.
 - `SoT:` An array for specific sources of truth. Git updater receives webhooks from github. Local: will use a local directory to update.
-- `Etcd`: (for a vaquero server cluster / HA) specifies the information used to connect a running etcd cluster to vaquero's own Etcd client. Etcd is used to keep track of state, data models, and other information in a persistent, distributed KV store.
+- `Etcd`: The necessary information to connect a vaquero server cluster or High Availability (HA) cluster to a running [CoreOS Etcd](https://coreos.com/etcd/) cluster. If Etcd information is provided, Vaquero will use the provided cluster endpoints (vs. a local filestorage) to store and continuously update data model information, as well as internal, vaquero-specific information (eg. machine state). See the [Getting Started page](https://ciscocloud.github.io/vaquero-docs/docs/current/getting-started.html), under "Etcd and Vaquero," for more information, including a short demo using a virtual machine running Etcd.
 - `DHCPMode`:Using "server" runs Vaquero as a DHCP server.  Vaquero does not manage free address pools or leases; it simply assigns based of the static configuration defined in the data model. **Note that DHCPMode defaults to server.** Using "proxy" enables ProxyDHCP. ProxyDHCP works with an existing DHCP Server to provide PXEBoot functionality, while leaving the managing and assigning of IP addresses to the other DHCP Server. Only enable this if you already have a DHCP server with entries for all the hosts in your Data Model.
 
 
@@ -177,7 +177,7 @@ Log:
 | Server | ServerAPI/Port        | no                | The port to serve the server REST API on                          | 24601              |
 | Server | ServerAPI/PrivateKey  | yes               | vaquero-server HTTPS/TLS Private Key                              | none               |
 | Server | ServerAPI/PublicKey   | yes               | vaquero-server HTTPS/TLS Public Key                               | none               |
-| Server | Etcd/Endpoints        | no                | etcd initial cluster endpoints: format- e1,e2,e3                  | 127.0.0.1:2379     |
+| Server | Etcd/Endpoints        | no                | etcd initial cluster endpoints: format- e1,e2,e3                  | none               |
 | Server | Etcd/Retry            | no                | number of retries for etcd operations                             | 3                  |
 | Server | Etcd/Timeout          | no                | etcd dial and request timeout, in seconds                         | 2                  |
 | Server | Gitter/Endpoint       | no                | githook endpoint to receive webhooks                              | /postreceive       |

--- a/docs/current/getting-started.md
+++ b/docs/current/getting-started.md
@@ -58,8 +58,8 @@ By default, the only ENVIRONMENT variable set is `VS_NUM=1`.
 
   For example: `VS_NUM=3 vagrant up` will stand up 3 vaquero server VMs. Running `vagrant destroy -f` will only destroy the first instance, you must run `VS_NUM=3 vagrant destroy -f` to clean up all of them. Include *every* ENV var for *every* vagrant command, even things like `vagrant ssh vs-3`.
 
-  **Etcd check:** Once the VM(s) are booted and before running vaquero, ssh into one of your server machines. Perform a cluster health check:
-  `ETCDCTL_API=2 etcdctl cluster-health`. If an error message appears, wait until all machines are live, then perform the cluster health check again.   
+  **etcd check:** Once the VM(s) are booted and before running vaquero, ssh into one of your server machines. Perform a cluster health check:
+  `etcdCTL_API=2 etcdctl cluster-health`. If an error message appears, wait until all machines are live, then perform the cluster health check again.   
 
 ## 3. pull the latest docker image
 
@@ -102,7 +102,52 @@ See the different [configurations](https://github.com/CiscoCloud/vaquero-vagrant
 `docker run -v /vagrant/config/dir-sot-agent.yaml:/vaquero/config.yaml -v /var/vaquero/files:/var/vaquero/files -v /vagrant/local:/vagrant/local -v /vagrant/provision_files/secret:/vaquero/secret --network="host" -e VAQUERO_SHARED_SECRET="<secret>" -e VAQUERO_SITE_ID="test-site"  shippedrepos-docker-vaquero.bintray.io/vaquero/vaquero:latest agent --config /vaquero/config.yaml`
 
 
-## demo lab
+## etcd and vaquero
+
+[CoreOS Etcd](https://coreos.com/etcd/) is a distributed, persistent key-value store. Vaquero users have the option to specify the use of an etcd cluster (vs. local filestorage) as Vaquero's internal storage. Vaquero will use that storage, in turn, to keep copies of SoTs, and to store internal information, such as tasks to be sent to Vaquero agents. Should the user elect to use their etcd cluster for Vaquero, it is up to them to maintain and secure the cluster; Vaquero simply reads and writes to the specified endpoints, and will not modify or add more nodes.
+
+The vaquero vagrant VM (described above) employs a single-node etcd cluster for demo and testing purposes. You can explore the `vaquero-vagrant` `provision-scripts` folder (`etcd-config.sh`, `etcd.sh`, and `etcd-start.sh`) to see how we install and boot the cluster on startup. The example below demonstrates how to configure vaquero to store information using Etcd.
+
+### how to run vaquero using etcd
+
+1. Inside your host machine, in the `vaquero-vagrant` repo, run: `V_DEV=1 VS_NUM=3 vagrant up`.
+2. `ssh` into two of the VMs: `V_DEV=1 VS_NUM=3 vagrant ssh vs-1` in one tab, `V_DEV=1 VS_NUM=3 vagrant ssh vs-2` in another.
+3. To test to make sure the cluster is running, put a key-value pair into `vs-1`:
+
+        [vagrant@vs-1 ~]$ etcdctl put hello world
+        OK
+
+4. In `vs-2`, try to fetch that key: `etcdctl get hello`.
+
+        [vagrant@vs-2 ~]$ etcdctl get hello
+        hello
+        world
+
+  *If you receive an empty output pair, or a grpc-related dialing issue on PUT, ensure that all three machines have booted before you continue. If you continue to have a problem, reboot each of the VMs, and then force-start Etcd: `sudo systemctl start etcd`. Check the cluster-health (`etcdCTL_API=2 etcdctl cluster-health`), then try to repeat steps 3-4.*
+
+5. Now that we've seen Etcd working on our vaquero server cluster, open up `/vagrant/config/dir-sot.yaml`. You'll see that Etcd information is already specified (replicated below). Note that the endpoints are the **only required** information to run etcd inside vaquero, but you can also optionally specify `timeout` (for each request, in seconds, default=2) and `retry` (number of retries per request, default=3). The `10.10.10.5 - 10.10.10.7` Endpoints are what the vagrant VM reserves for servers (see "Virtualenv Layout" on this page), and the `2379` port is what we specified as our Etcd client endpoints on boot.
+
+      Etcd:
+        Endpoints:
+        - "http://10.10.10.5:2379"
+        - "http://10.10.10.6:2379"
+        - "http://10.10.10.7:2379"
+        Timeout: 5
+        Retry: 3
+
+6. Run vaquero using `dir-sot.yaml` from the container:
+
+      docker run -v /vagrant/config/dir-sot.yaml:/vaquero/config.yaml -v /var/vaquero/files:/var/vaquero/files -v /vagrant/local:/vagrant/local -v /vagrant/provision_files/secret:/vaquero/secret --network="host" -e VAQUERO_SHARED_SECRET="<secret>" -e VAQUERO_SERVER_SECRET="<secret>" -e VAQUERO_SITE_ID="test-site" shippedrepos-docker-vaquero.bintray.io/vaquero/vaquero:latest standalone --config /vaquero/config.yaml
+
+7. You should see some etcd-related startup messages in the log output, including a successful Etcd PUT of the vagrant VM's local SOT. Success!
+
+        time="2016-12-15T21:46:28Z" level=debug msg="Etcd client initialized at endpoints: [http://10.10.10.5:2379 http://10.10.10.6:2379 http://10.10.10.7:2379]" package=storage
+        time="2016-12-15T21:46:28Z" level=info msg="Initialized etcd store for vaquero-local/test-site" package="server/controller"
+        time="2016-12-15T21:46:28Z" level=debug msg="Successful Etcd Get (withPrefix=false) for key model/current" package=storage
+        time="2016-12-15T21:46:28Z" level=debug msg="Successful Etcd Put for key model/current" package=storage
+
+
+## vaquero demo lab
 
 Vaquero provides this vagrant environment as a sandbox to work with vaquero before deployment. We provide 9 mac -> IP mappings that are free for your use / testing, the machines labeled SANDBOX would be free. We also provide two example data models, one as a [github](https://github.com/CiscoCloud/vaquero-examples/tree/vagrant) SoT and a local dir SoT, [vaquero-vagrant](https://github.com/CiscoCloud/vaquero-vagrant/tree/master/local). These define the demo machines and are a working data model to use as an example when you develop your own SoT.
 

--- a/docs/current/getting-started.md
+++ b/docs/current/getting-started.md
@@ -111,7 +111,7 @@ The vaquero vagrant VM (described above) has a running etcd cluster baked in. Yo
 ### how to run vaquero using etcd
 
 1. Inside your host machine, in the `vaquero-vagrant` repo, run: `V_DEV=1 VS_NUM=3 vagrant up`. This will boot up a cluster of three vaquero servers, running on `10.10.10.5 - 10.10.10.7`.
-2. `ssh` into two of the VMs: `V_DEV=1 VS_NUM=3 vagrant ssh vs-1` in one tab, `V_DEV=1 VS_NUM=3 vagrant ssh vs-2` in another.
+2. **Test your cluster:** `ssh` into two of the VMs: `V_DEV=1 VS_NUM=3 vagrant ssh vs-1` in one tab, `V_DEV=1 VS_NUM=3 vagrant ssh vs-2` in another. (**Note:** this example uses three Vaquero servers, but you can start any number of VS machines (even one!), as long as each machine is configured for Etcd.)
 3. To test to make sure the cluster is running, put a key-value pair into `vs-1`:
 
         [vagrant@vs-1 ~]$ etcdctl put hello world
@@ -125,7 +125,7 @@ The vaquero vagrant VM (described above) has a running etcd cluster baked in. Yo
 
   *If you receive an empty output pair, or a grpc-related dialing issue on PUT, ensure that all three machines have booted before you continue. If you continue to have a problem, reboot each of the VMs, and then force-start Etcd: `sudo systemctl start etcd`. Check the cluster-health (`etcdCTL_API=2 etcdctl cluster-health`), then try to repeat steps 3-4.*
 
-5. Now that we've seen Etcd working on our vaquero server cluster, open up `/vagrant/config/dir-sot.yaml`. You'll see that Etcd information is already specified (replicated below). Note that the endpoints are the **only required** information to run etcd inside vaquero, but you can also optionally specify `timeout` (for each request, in seconds, default=2) and `retry` (number of retries per request, default=3). The `10.10.10.5 - 10.10.10.7` Endpoints are what the vagrant VM reserves for servers (see "Virtualenv Layout" on this page), and the `2379` port is what we specified as our Etcd client endpoints on boot.
+5. Now that we've seen Etcd working on our vaquero server cluster, open up any server config (I used `/vagrant/config/dir-sot.yaml`). If you use `dir-sot.yaml`, you'll see that Etcd information is already specified (replicated below). Note that the endpoints are the **only required** information to run etcd inside vaquero, but you can also optionally specify `timeout` (for each request, in seconds, default=2) and `retry` (number of retries per request, default=3). The `10.10.10.5 - 10.10.10.7` Endpoints are what the vagrant VM reserves for servers (see "Virtualenv Layout" on this page), and the `2379` port is what we specified as our Etcd client endpoints on boot. If there is no Etcd information in your config, add it to the YAML.
 
         Etcd:
           Endpoints:
@@ -135,10 +135,10 @@ The vaquero vagrant VM (described above) has a running etcd cluster baked in. Yo
           Timeout: 5
           Retry: 3
 
-6. Run vaquero using `dir-sot.yaml` from the container:
+6. Run vaquero from the container (this command uses `dir-sot.yaml`, replace with the config you used)
 `docker run -v /vagrant/config/dir-sot.yaml:/vaquero/config.yaml -v /var/vaquero/files:/var/vaquero/files -v /vagrant/local:/vagrant/local -v /vagrant/provision_files/secret:/vaquero/secret --network="host" -e VAQUERO_SHARED_SECRET="<secret>" -e VAQUERO_SERVER_SECRET="<secret>" -e VAQUERO_SITE_ID="test-site" shippedrepos-docker-vaquero.bintray.io/vaquero/vaquero:latest standalone --config /vaquero/config.yaml`
 
-7. You should see some etcd-related startup messages in the log output, including a successful Etcd PUT of the vagrant VM's local SOT. Success!
+7. You should now see some etcd-related startup messages in the log output, including a successful Etcd PUT of the vagrant VM's local SOT. Success!
 
         time="2016-12-15T21:46:28Z" level=debug msg="Etcd client initialized at endpoints: [http://10.10.10.5:2379 http://10.10.10.6:2379 http://10.10.10.7:2379]" package=storage
         time="2016-12-15T21:46:28Z" level=info msg="Initialized etcd store for vaquero-local/test-site" package="server/controller"

--- a/docs/current/getting-started.md
+++ b/docs/current/getting-started.md
@@ -127,13 +127,13 @@ The vaquero vagrant VM (described above) has a running etcd cluster baked in. Yo
 
 5. Now that we've seen Etcd working on our vaquero server cluster, open up `/vagrant/config/dir-sot.yaml`. You'll see that Etcd information is already specified (replicated below). Note that the endpoints are the **only required** information to run etcd inside vaquero, but you can also optionally specify `timeout` (for each request, in seconds, default=2) and `retry` (number of retries per request, default=3). The `10.10.10.5 - 10.10.10.7` Endpoints are what the vagrant VM reserves for servers (see "Virtualenv Layout" on this page), and the `2379` port is what we specified as our Etcd client endpoints on boot.
 
-      Etcd:
-        Endpoints:
-        - "http://10.10.10.5:2379"
-        - "http://10.10.10.6:2379"
-        - "http://10.10.10.7:2379"
-        Timeout: 5
-        Retry: 3
+        Etcd:
+          Endpoints:
+          - "http://10.10.10.5:2379"
+          - "http://10.10.10.6:2379"
+          - "http://10.10.10.7:2379"
+          Timeout: 5
+          Retry: 3
 
 6. Run vaquero using `dir-sot.yaml` from the container:
 `docker run -v /vagrant/config/dir-sot.yaml:/vaquero/config.yaml -v /var/vaquero/files:/var/vaquero/files -v /vagrant/local:/vagrant/local -v /vagrant/provision_files/secret:/vaquero/secret --network="host" -e VAQUERO_SHARED_SECRET="<secret>" -e VAQUERO_SERVER_SECRET="<secret>" -e VAQUERO_SITE_ID="test-site" shippedrepos-docker-vaquero.bintray.io/vaquero/vaquero:latest standalone --config /vaquero/config.yaml`

--- a/docs/current/getting-started.md
+++ b/docs/current/getting-started.md
@@ -58,8 +58,8 @@ By default, the only ENVIRONMENT variable set is `VS_NUM=1`.
 
   For example: `VS_NUM=3 vagrant up` will stand up 3 vaquero server VMs. Running `vagrant destroy -f` will only destroy the first instance, you must run `VS_NUM=3 vagrant destroy -f` to clean up all of them. Include *every* ENV var for *every* vagrant command, even things like `vagrant ssh vs-3`.
 
-  **etcd check:** Once the VM(s) are booted and before running vaquero, ssh into one of your server machines. Perform a cluster health check:
-  `etcdCTL_API=2 etcdctl cluster-health`. If an error message appears, wait until all machines are live, then perform the cluster health check again.   
+  **Etcd check:** Once the VM(s) are booted and before running vaquero, ssh into one of your server machines. Perform a cluster health check:
+  `ETCDCTL_API=2 etcdctl cluster-health`. If an error message appears, wait until all machines are live, then perform the cluster health check again.   
 
 ## 3. pull the latest docker image
 

--- a/docs/current/getting-started.md
+++ b/docs/current/getting-started.md
@@ -106,11 +106,11 @@ See the different [configurations](https://github.com/CiscoCloud/vaquero-vagrant
 
 [CoreOS Etcd](https://coreos.com/etcd/) is a distributed, persistent key-value store. Vaquero users have the option to specify the use of an etcd cluster (vs. local filestorage) as Vaquero's internal storage. Vaquero will use that storage, in turn, to keep copies of SoTs, and to store internal information, such as tasks to be sent to Vaquero agents. Should the user elect to use their etcd cluster for Vaquero, it is up to them to maintain and secure the cluster; Vaquero simply reads and writes to the specified endpoints, and will not modify or add more nodes.
 
-The vaquero vagrant VM (described above) employs a single-node etcd cluster for demo and testing purposes. You can explore the `vaquero-vagrant` `provision-scripts` folder (`etcd-config.sh`, `etcd.sh`, and `etcd-start.sh`) to see how we install and boot the cluster on startup. The example below demonstrates how to configure vaquero to store information using Etcd.
+The vaquero vagrant VM (described above) has a running etcd cluster baked in. You can explore the `vaquero-vagrant` `provision-scripts` folder (`etcd-config.sh`, `etcd.sh`, and `etcd-start.sh`) to see how we install and start up etcd every time we boot a machine. The example below demonstrates how to configure vaquero to use etcd.
 
 ### how to run vaquero using etcd
 
-1. Inside your host machine, in the `vaquero-vagrant` repo, run: `V_DEV=1 VS_NUM=3 vagrant up`.
+1. Inside your host machine, in the `vaquero-vagrant` repo, run: `V_DEV=1 VS_NUM=3 vagrant up`. This will boot up a cluster of three vaquero servers, running on `10.10.10.5 - 10.10.10.7`.
 2. `ssh` into two of the VMs: `V_DEV=1 VS_NUM=3 vagrant ssh vs-1` in one tab, `V_DEV=1 VS_NUM=3 vagrant ssh vs-2` in another.
 3. To test to make sure the cluster is running, put a key-value pair into `vs-1`:
 
@@ -136,8 +136,7 @@ The vaquero vagrant VM (described above) employs a single-node etcd cluster for 
         Retry: 3
 
 6. Run vaquero using `dir-sot.yaml` from the container:
-
-      docker run -v /vagrant/config/dir-sot.yaml:/vaquero/config.yaml -v /var/vaquero/files:/var/vaquero/files -v /vagrant/local:/vagrant/local -v /vagrant/provision_files/secret:/vaquero/secret --network="host" -e VAQUERO_SHARED_SECRET="<secret>" -e VAQUERO_SERVER_SECRET="<secret>" -e VAQUERO_SITE_ID="test-site" shippedrepos-docker-vaquero.bintray.io/vaquero/vaquero:latest standalone --config /vaquero/config.yaml
+`docker run -v /vagrant/config/dir-sot.yaml:/vaquero/config.yaml -v /var/vaquero/files:/var/vaquero/files -v /vagrant/local:/vagrant/local -v /vagrant/provision_files/secret:/vaquero/secret --network="host" -e VAQUERO_SHARED_SECRET="<secret>" -e VAQUERO_SERVER_SECRET="<secret>" -e VAQUERO_SITE_ID="test-site" shippedrepos-docker-vaquero.bintray.io/vaquero/vaquero:latest standalone --config /vaquero/config.yaml`
 
 7. You should see some etcd-related startup messages in the log output, including a successful Etcd PUT of the vagrant VM's local SOT. Success!
 


### PR DESCRIPTION
Closes https://github.com/CiscoCloud/vaquero/issues/545

Provides a description of what vaquero uses Etcd for, and shows (using the vagrant VMs) how they'd configure and run vaquero using their own etcd info. 

Changes under "Etcd and Vaquero" https://ciscocloud.github.io/vaquero-docs/docs/branches/etcd/getting-started.html